### PR TITLE
Feature add support to disable ipv6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,6 +142,21 @@ sysctl__default_parameters:
         comment: 'Enable or disable IPv4 traffic forwarding'
         state: 'present'
 
+      - name: 'net.ipv6.conf.all.forwarding'
+        value: '{{ sysctl__system_ip_forwarding_enabled|bool | ternary(1, 0) }}'
+        comment: 'Enable or disable IPv6 traffic forwarding'
+        state: 'present'
+
+      - name: 'net.ipv6.conf.all.accept_ra'
+        value: 0
+        comment: 'Ignore IPv6 RAs.'
+        state: '{{ sysctl__hardening_enabled|bool | ternary("present", "absent") }}'
+
+      - name: 'net.ipv6.conf.default.accept_ra'
+        value: 0
+        comment: 'Ignore IPv6 RAs.'
+        state: '{{ sysctl__hardening_enabled|bool | ternary("present", "absent") }}'
+
       - name: 'net.ipv4.conf.all.rp_filter'
         value: 1
         comment: 'Enable RFC-recommended source validation feature.'
@@ -180,6 +195,11 @@ sysctl__default_parameters:
           source quench, ime exceed, param problem, timestamp reply,
           information reply
         state: '{{ sysctl__hardening_enabled|bool | ternary("present", "absent") }}'
+
+      - name: 'net.ipv6.conf.all.disable_ipv6'
+        value: 1
+        comment: 'Disable IPv6.'
+        state: '{{ sysctl__hardening_ipv6_disabled|bool | ternary("present", "absent") }}'
 
       - name: 'net.ipv4.tcp_timestamps'
         value: 0

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: grub restart
+  command: update-grub

--- a/tasks/ipv6-grub-disable.yml
+++ b/tasks/ipv6-grub-disable.yml
@@ -1,0 +1,8 @@
+---
+- name: 3.1.1 Disable IPv6
+  replace:
+    dest: /etc/default/grub
+    regexp: '^(GRUB_CMDLINE_LINUX=(?!.*ipv6.disable)\"[^\"]*)(\".*)'
+    replace: '\1 ipv6.disable=1\2'
+  notify:
+    - grub restart

--- a/tasks/ipv6-grub-disable.yml
+++ b/tasks/ipv6-grub-disable.yml
@@ -1,5 +1,5 @@
 ---
-- name: 3.1.1 Disable IPv6
+- name: Disable IPv6 on grub
   replace:
     dest: /etc/default/grub
     regexp: '^(GRUB_CMDLINE_LINUX=(?!.*ipv6.disable)\"[^\"]*)(\".*)'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,7 +112,7 @@
   when: sysctl__register_config_created is changed or
         sysctl__register_config_removed is changed
 
-- name: Include disbale ipv6 on grub
+- name: Include disable ipv6 on grub
   include: ipv6-grub-disable.yml
   when: sysctl__hardening_ipv6_disabled
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,5 +112,9 @@
   when: sysctl__register_config_created is changed or
         sysctl__register_config_removed is changed
 
+- name: Include disbale ipv6 on grub
+  include: ipv6-grub-disable.yml
+  when: sysctl__hardening_ipv6_disabled
+
 - name: Post hooks
   include: '{{ lookup("task_src", "sysctl/post_main.yml") }}'


### PR DESCRIPTION
Add support to disable ipv6.
Add permanet disable ipv6 on grub.
This features are necessary due to cis level1 is not compatible with some services.
@DevoInc/cloudops 